### PR TITLE
Update metadata to be more descriptive

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ serial_number: '036'
 doc_id: 'DMTN-036'
 
 # Title of the document, without the series/serial designation
-doc_title: 'The Jointcal algorithm'
+doc_title: 'Jointcal: Simultaneous Astrometry and Photometry'
 
 # Author names, ordered as a list. Each author name should be formatted as 'First Last'
 authors:
@@ -37,7 +37,7 @@ authors:
 copyright: '2017, AURA/LSST'
 
 # Description. A short, 1-2 sentence statemement used by document indices.
-description: 'This note describes jointcal’s algorithm, fitting process, and currently available models.'
+description: 'A description of the jointcal algorithm, for performing simultaneous astrometry and photometry for thousands of exposures with large CCD mosaics.'
 
 # Abstract, if available
 # abstract: >


### PR DESCRIPTION
I noticed on the lsst.io summary page that this entry was not very helpful. I've updated the metadata title and description to more closely match the .tex version.